### PR TITLE
JreLocaleContext.localeText returns Optional empty String FIX

### DIFF
--- a/src/main/java/walkingkooka/locale/JreLocaleContextLocaleText.java
+++ b/src/main/java/walkingkooka/locale/JreLocaleContextLocaleText.java
@@ -18,6 +18,7 @@
 package walkingkooka.locale;
 
 import javaemul.internal.annotations.GwtIncompatible;
+import walkingkooka.text.CharSequences;
 
 import java.util.Locale;
 import java.util.Optional;
@@ -26,8 +27,12 @@ class JreLocaleContextLocaleText extends JreLocaleContextLocaleTextGwt {
 
     @GwtIncompatible
     static Optional<String> localeText(final Locale locale) {
-        return Optional.of(
-                locale.getDisplayName()
+        final String displayName = locale.getDisplayName();
+
+        return Optional.ofNullable(
+                CharSequences.isNullOrEmpty(displayName) ?
+                        null :
+                        displayName
         );
     }
 }

--- a/src/test/java/walkingkooka/locale/JreLocaleContextTest.java
+++ b/src/test/java/walkingkooka/locale/JreLocaleContextTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.collect.set.Sets;
 
 import java.util.Locale;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -43,6 +44,18 @@ public final class JreLocaleContextTest implements LocaleContextTesting2<JreLoca
                 this.createContext()
                         .availableLocales()
         );
+    }
+
+    @Test
+    public void testLocaleText() {
+        for(final Locale locale : Locale.getAvailableLocales()) {
+            final JreLocaleContext context = JreLocaleContext.with(locale);
+            this.checkNotEquals(
+                    Optional.of(""),
+                    context.localeText(locale),
+                    locale::toLanguageTag
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
- Previously localeText(Locale=UND) returned Optional.of("") it now returns Optional.empty()